### PR TITLE
Updated droidbox URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ Additional features:
 
 * Takes a screenshot every 5 seconds
 
-  [1]: https://code.google.com/p/droidbox/
+  [1]: https://github.com/pjlantz/droidbox
   [2]: https://registry.hub.docker.com/u/honeynet/droidbox/
   [3]: https://github.com/aikinci/droidbox


### PR DESCRIPTION
With the retirement of Google Code, Droidbox migrated here to GitHub. This just fixes the URL in the README.